### PR TITLE
Making sure that reference exists (used to sefgfault)

### DIFF
--- a/src/utility/program_parameters.cc
+++ b/src/utility/program_parameters.cc
@@ -7,6 +7,7 @@
 
 #include "utility/program_parameters.h"
 #include "utility/argumentparser.h"
+#include "utility/utility_general.h"
 
 int ProcessArgs1(int argc, char **argv, ProgramParameters *parameters)
 {
@@ -398,6 +399,12 @@ int ProcessArgs(int argc, char **argv, ProgramParameters *parameters)
     fprintf (stderr, "\n");
     VerboseShortHelpAndExit(argc, argv);
   }
+
+
+  if (! fileExists(parameters->reference_path.c_str())) {
+      fprintf (stderr, "Reference does not exist: %s\n\n", parameters->reference_path.c_str());
+      VerboseShortHelpAndExit(argc, argv);
+   }
 
   // Check if the index path was specified, if not, generate it.
   if (parameters->index_reference_path.size() == 0)

--- a/src/utility/utility_general.cc
+++ b/src/utility/utility_general.cc
@@ -18,6 +18,16 @@
 #include "log_system/log_system.h"
 
 
+int fileExists(const char *fname) {
+     /* from
+      * http://stackoverflow.com/questions/230062/whats-the-best-way-to-check-if-a-file-exists-in-c-cross-platform
+      */
+     if (access(fname, F_OK) != -1) {
+          return 1;
+     } else {
+          return 0;
+     }
+}
 
 std::string GetUTCTime(std::string fmt) {
   //  const char* fmt = "%a, %d %b %y %T %z";

--- a/src/utility/utility_general.h
+++ b/src/utility/utility_general.h
@@ -14,7 +14,7 @@
 #include <sstream>
 #include <vector>
 #include <algorithm>
-
+#include <numeric> 
 
 
 enum SeqOrientation {
@@ -75,6 +75,7 @@ enum ProcessedReadState {
 
 
 
+int fileExists(const char *fname);
 std::string GetUTCTime(std::string fmt="%a, %d %b %y %T %z");
 std::string GetLocalTime();
 void ProcessMemUsage(double& vm_usage, double& resident_set);


### PR DESCRIPTION
Graphmap did not check if the given reference fasta file exists and consequently segfaulted in LoadOrGenerate(). Added check during user argument parsing.