### PR TITLE
Fix seg fault

### DIFF
--- a/src/alignment/alignment.cc
+++ b/src/alignment/alignment.cc
@@ -311,7 +311,8 @@ int CheckAlignmentSane(std::vector<unsigned char> &alignment, const SingleSequen
     return 4;
   }
   if ((index != nullptr && reference_hit_id >= 0 && reference_hit_pos >= 0) &&
-      (reference_hit_pos + ref_length) > (index->get_reference_starting_pos()[reference_hit_id] + index->get_reference_lengths()[reference_hit_id])) {
+      ((reference_hit_pos < index->get_reference_starting_pos()[reference_hit_id]) ||
+       (reference_hit_pos + ref_length) > (index->get_reference_starting_pos()[reference_hit_id] + index->get_reference_lengths()[reference_hit_id]))) {
     LOG_DEBUG("CheckAlignmentSane returned false! return 5. Alignment steps out of bounds of the reference.\n"
 	"\treference_hit_id = %ld\n"
         "\treference_hit_pos = %ld, ref_length = %ld\n"

--- a/src/alignment/anchored.cc
+++ b/src/alignment/anchored.cc
@@ -5,6 +5,7 @@
  *      Author: isovic
  */
 
+#include <cassert>
 #include <alignment/alignment_wrappers.h>
 #include "alignment/alignment.h"
 
@@ -854,35 +855,36 @@ int AnchoredAlignmentNew(AlignmentFunctionType AlignmentFunctionNW, AlignmentFun
       ConvertFromTranscriptomeToGenomeAln(parameters, index, transcriptome, curr_aln);
     }
 
-    LOG_DEBUG_SPEC("Converting alignment to CIGAR string.\n");
-    curr_aln->cigar = AlignmentToCigar((unsigned char *) &(curr_aln->alignment[0]), curr_aln->alignment.size(), parameters->use_extended_cigar);
+    if (curr_aln->is_aligned) {
+      LOG_DEBUG_SPEC("Converting alignment to CIGAR string.\n");
+      curr_aln->cigar = AlignmentToCigar((unsigned char *) &(curr_aln->alignment[0]), curr_aln->alignment.size(), parameters->use_extended_cigar);
 
-    LOG_DEBUG_SPEC("Converting alignment to MD string.\n");
-    curr_aln->md = AlignmentToMD((std::vector<unsigned char> &) curr_aln->alignment, &index->get_data()[0], final_aln_pos_start);
+      LOG_DEBUG_SPEC("Converting alignment to MD string.\n");
+      curr_aln->md = AlignmentToMD((std::vector<unsigned char> &) curr_aln->alignment, &index->get_data()[0], final_aln_pos_start);
 
 //    printf ("final_aln_pos_start = %ld\n", final_aln_pos_start);
 //    printf ("Query:\n%s\nTarget:\n%s\n", GetSubstring((char *) read->get_data(), read->get_data_length()).c_str(), GetSubstring((char *) index->get_data() + final_aln_pos_start, read->get_data_length()).c_str());
 //    fflush(stdout);
 
-    LOG_DEBUG_SPEC("Counting alignment operations.\n");
-    CountAlignmentOperations((std::vector<unsigned char> &) curr_aln->raw_alignment, read->get_data(), &index->get_data()[0], abs_ref_id, curr_aln->raw_pos_start, orientation,
-                             parameters->evalue_match, parameters->evalue_mismatch, parameters->evalue_gap_open, parameters->evalue_gap_extend, true,
-                             &curr_aln->num_eq_ops, &curr_aln->num_x_ops, &curr_aln->num_i_ops, &curr_aln->num_d_ops, &curr_aln->alignment_score, &curr_aln->edit_distance, &curr_aln->nonclipped_length);
+      LOG_DEBUG_SPEC("Counting alignment operations.\n");
+      CountAlignmentOperations((std::vector<unsigned char> &) curr_aln->raw_alignment, read->get_data(), &index->get_data()[0], abs_ref_id, curr_aln->raw_pos_start, orientation,
+                               parameters->evalue_match, parameters->evalue_mismatch, parameters->evalue_gap_open, parameters->evalue_gap_extend, true,
+                               &curr_aln->num_eq_ops, &curr_aln->num_x_ops, &curr_aln->num_i_ops, &curr_aln->num_d_ops, &curr_aln->alignment_score, &curr_aln->edit_distance, &curr_aln->nonclipped_length);
 //    LOG_DEBUG_SPEC("Calculating the E-value.\n");
 //    CalculateEValueDNA(curr_aln->alignment_score, curr_aln->nonclipped_length, index->get_data_length_forward(), evalue_params, &curr_aln->evalue);
 
-    LOG_DEBUG_SPEC("Calculating alignment statistics.\n");
-    double error_rate = ((double) curr_aln->num_x_ops + curr_aln->num_i_ops + curr_aln->num_d_ops) / ((double) curr_aln->nonclipped_length);
-    double indel_error_rate = ((double) curr_aln->num_i_ops + curr_aln->num_d_ops) / ((double) curr_aln->nonclipped_length);
-    if (error_rate > parameters->max_error_rate) {
-      curr_aln->is_aligned = false;
-      LOG_DEBUG_SPEC("Error rate is too high! error_rate = %lf, parameters->max_error_rate = %lf\n", error_rate, parameters->max_error_rate);
+      LOG_DEBUG_SPEC("Calculating alignment statistics.\n");
+      double error_rate = ((double) curr_aln->num_x_ops + curr_aln->num_i_ops + curr_aln->num_d_ops) / ((double) curr_aln->nonclipped_length);
+      double indel_error_rate = ((double) curr_aln->num_i_ops + curr_aln->num_d_ops) / ((double) curr_aln->nonclipped_length);
+      if (error_rate > parameters->max_error_rate) {
+        curr_aln->is_aligned = false;
+        LOG_DEBUG_SPEC("Error rate is too high! error_rate = %lf, parameters->max_error_rate = %lf\n", error_rate, parameters->max_error_rate);
+      }
+      if (indel_error_rate > parameters->max_indel_error_rate) {
+        curr_aln->is_aligned = false;
+        LOG_DEBUG_SPEC("Indel error rate is too high! error_rate = %lf, parameters->max_error_rate = %lf\n", error_rate, parameters->max_error_rate);
+      }
     }
-    if (indel_error_rate > parameters->max_indel_error_rate) {
-      curr_aln->is_aligned = false;
-      LOG_DEBUG_SPEC("Indel error rate is too high! error_rate = %lf, parameters->max_error_rate = %lf\n", error_rate, parameters->max_error_rate);
-    }
-
     VerboseAlignment(read, index, parameters, curr_aln);
   }
 
@@ -1027,7 +1029,9 @@ int AnchoredAlignmentNew(AlignmentFunctionType AlignmentFunctionNW, AlignmentFun
     /// final_aln_pos_start is the alignment position within the reference (local to the reference), and is also reversed (subtracted from reference_length) in case orientation == kReverse.
     int64_t final_aln_pos_start = 0, final_aln_pos_end = 0;
     index->RawPositionConverterWithRefId((curr_aln->orientation == kForward) ? curr_aln->raw_pos_start : curr_aln->raw_pos_end, abs_ref_id, 0, NULL, &final_aln_pos_start, NULL);
+    assert(final_aln_pos_start >= 0);
     index->RawPositionConverterWithRefId((curr_aln->orientation == kForward) ? curr_aln->raw_pos_end : curr_aln->raw_pos_start, abs_ref_id, 0, NULL, &final_aln_pos_end, NULL);
+    assert(final_aln_pos_end >= 0);
     curr_aln->ref_start = final_aln_pos_start; // % ref_len;
     curr_aln->ref_end = final_aln_pos_end; // % ref_len;
 

--- a/src/alignment/cigargen.cc
+++ b/src/alignment/cigargen.cc
@@ -5,6 +5,7 @@
  *      Author: ivan
  */
 
+#include <cassert>
 #include "alignment/cigargen.h"
 #include "utility/utility_general.h"
 
@@ -521,6 +522,7 @@ int CountAlignmentOperations(std::vector<unsigned char>& alignment, const int8_t
                              int64_t match, int64_t mismatch, int64_t gap_open, int64_t gap_extend,
                              bool skip_leading_and_trailing_insertions,
                              int64_t* ret_eq, int64_t* ret_x, int64_t* ret_i, int64_t* ret_d, int64_t *ret_alignment_score, int64_t *ret_edit_dist, int64_t *ret_nonclipped_length) {
+  assert(alignment_position_start >= 0);
   unsigned char last_move = -1;  // Code of last move.
   int64_t num_same_moves = 0;
   int64_t read_position = 0;
@@ -601,6 +603,7 @@ int CountAlignmentOperations(std::vector<unsigned char>& alignment, const int8_t
  * for a CIGAR "5=2I3=" the MD would be "8".
  */
 std::string AlignmentToMD(std::vector<unsigned char>& alignment, const int8_t *ref_data, int64_t alignment_position_start) {
+  assert(alignment_position_start >= 0);
   std::vector<CigarOp> cigar_array;
   AlignmentToExtendedCigarArray(&alignment[0], alignment.size(), cigar_array);
 //  printf("\n");


### PR DESCRIPTION
For some of my datasets with many smaller scaffolds, I found that the latest version of graphmap was segfaulting again on certain reads.  When I dove deep into the debugger, I found that the start alignment positions were negative so there was a buffer underrun on the reference sequence.

Additionally even when an alignment is classified as insane and is_aligned is false, the MD and metrics were still being called.  I fixed that so that there would not be a buffer under run there too.

This patch adds assertions in cigargen.cc: CountAlignmentOperations() and AlignmentToMD()
And performs additional checks for insane alignments and avoids alignment calculations when is_aligned is false

I did not investigate why certain alignments were being calculated outside the bounds of the reference sequence, which would be a better fix, but at least this stops the segfaults on my datasets.


I have also not verified, but this could also fix issue #60 and #43 