### PR TITLE
Added docker build files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+deprecated/
+temp/
+temp/*
+obj/
+obj_debug/
+obj_linux/
+obj_mac/
+obj_test/
+obj_testext/
+obj_extcigar/
+# bin/graphmap-not_release
+# bin/graphmap-debug
+bin/
+.project
+.cproject
+.settings/
+reproducibility/*/
+test-data/
+
+!reproducibility/*.py
+!reproducibility/*.md
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu as builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        zlib1g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /opt/graphmap
+COPY . .
+RUN make && make install
+ENTRYPOINT ["/usr/bin/graphmap"]
+
+# Second stage -- smaller image (( 400MB before --> 117MB now ))
+FROM ubuntu
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        zlib1g \
+        libgomp1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /data
+COPY --from=builder /usr/bin/graphmap /usr/bin/graphmap
+ENTRYPOINT ["/usr/bin/graphmap"]
+

--- a/Makefile
+++ b/Makefile
@@ -200,3 +200,21 @@ rebuildmac: cleanmac mac
 # divsufsort:
 # 	cd libs; ./build-libdivsufsort.sh
 
+USERNAME=""
+TAG="latest"
+
+ifeq ($(strip $(USERNAME)), "")
+	BASE_TAG=""
+else
+	BASE_TAG=$(USERNAME)/
+endif
+
+docker-build: modules
+	docker build -t $(BASE_TAG)graphmap:$(TAG) .
+
+.PHONY: docker-build
+
+docker-push: docker-build
+	docker push $(BASE_TAG)graphmap:$(TAG)
+
+.PHONY: docker-push

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Ra attempts to create *de novo* assemblies from raw nanopore and PacBio reads wi
 Currently, development of a new spliced-alignment mode for mapping RNA-seq reads is under way.  
 Description of the current effort as well as how to reach the experimental implementation can be found here: [doc/rnaseq.md](doc/rnaseq.md).  
 
+### Docker quick start
+```
+make docker-build
+docker run --rm -it -v <data_dir>:/data -w /data -it --rm graphmap align -C -r reference.fa -d reads.fasta -o output.sam
+```
 
 ### Quick start on Linux x64
 ```  


### PR DESCRIPTION
This PR Adds required files for docker building a small image containing only graphmap and basic ubuntu runtime (( since I wasn't able to build graphmap statically )). 

It adds a description in the readme how to use it. 

I recommend to the project owner building up-to-date graphmap docker image and publishing it to dockerhub. 

After doing so, docker quickstart would be:
```
docker run --rm -it -v <data_dir>:/data -w /data -it --rm isovic/graphmap align -C -r reference.fa -d reads.fasta -o output.sam
```

without any need for any extra dependencies.